### PR TITLE
🍏 use different args for base64 depends on platform

### DIFF
--- a/autoload/scap.vim
+++ b/autoload/scap.vim
@@ -11,6 +11,14 @@ function! scap#BuildTitle()
   return l:file_name . ' Line:' . l:select_from . '%7E' . l:select_to "%7E = ~
 endfunction
 
+function! scap#EncodeBase64(code)
+  if has('macunix')
+    return system('echo ' . shellescape(a:code) . ' | base64')
+  elseif has("linux")
+    return system('echo ' . shellescape(a:code) . ' | base64 --wrap=0 --ignore-garbage')
+  endif
+endfunction
+
 function! scap#Capture() range
   let l:code = join(scap#GetSelectedLines(), "\r\n")
   let l:urlBase = 'https://ray.so'
@@ -19,7 +27,7 @@ function! scap#Capture() range
   let l:colors = 'breeze'
   let l:dark_mode = 'true'
   let l:padding = 32
-  let l:codeBase64 = system('echo ' . shellescape(l:code) . ' | base64 --wrap=0 --ignore-garbage')
+  let l:codeBase64 = scap#EncodeBase64(l:code)
 
   let l:url = l:urlBase
      \. '?title=' . l:title


### PR DESCRIPTION
* add a function to encode text with base64 which can support both linux and macos
